### PR TITLE
Added optional initialization flags

### DIFF
--- a/src/main.lisp
+++ b/src/main.lisp
@@ -157,16 +157,16 @@ primarily so it can be easily redefined without starting/stopping."
                        (return-from main-loop)))
                  (sdl2:sdl-continue (c) (declare (ignore c))))))))
 
-(defun init ()
+(defun init (&optional (init-flags '(:everything)))
   (handler-case
-      (unless (sdl2:was-init :everything)
-        (sdl2:init :everything))
+      (unless (apply #'sdl2:was-init init-flags)
+        (apply #'sdl2:init init-flags))
     (error () (setf *started* nil))))
 
-(defun start (&optional function)
+(defun start (&optional function (init-flags '(:everything)))
   (unless *started*
     (setf *started* t)
-    (init)
+    (init init-flags)
     (when *started*
       (sdl2:in-main-thread (:background t :no-event t)
         (unwind-protect


### PR DESCRIPTION
When attempting to run `(kit.sdl2:start)` on FreeBSD I was prompted with the error `SDL Error (-1): SDL not built with haptic (force feedback) support.` As it turns out FreeBSD does not yet have SDL2 haptic support, but since haptic support isn't crucial it'd be nice to disable it. SDL2Kit presently initializes everything by default, without an option to disable particular modules, so I added some optional arguments to support this. Preexisting code calling _kit.sdl2:start_ will still function as intended.
Example usage:
```
;; Initialize everything but haptic
(kit.sdl2:start nil
                '(sdl2-ffi:+sdl-init-timer+ sdl2-ffi:+sdl-init-audio+
                  sdl2-ffi:+sdl-init-video+ sdl2-ffi:+sdl-init-joystick+
                  sdl2-ffi:+sdl-init-gamecontroller+
                  sdl2-ffi:+sdl-init-noparachute+))

;; Still initializes everything when called without arguments
(kit.sdl2:start)
```